### PR TITLE
增加6-4e圣捞

### DIFF
--- a/assets/resource/pipeline/tasks/combat/dollRescue/residentRescue/6-4eRescue.json
+++ b/assets/resource/pipeline/tasks/combat/dollRescue/residentRescue/6-4eRescue.json
@@ -1,0 +1,960 @@
+{
+    "!6-4e打捞总流程":{
+        "next":[
+            "6-4e点击指挥部0"
+        ]
+    },
+    "6-4e点击指挥部0":{
+        "recognition": "OCR",
+        "roi" : [1043,666,96,28],
+        "expected":"点击指挥部",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [256,689,18,24],
+        "post_delay":200,
+        "next": [
+            "6-4e部署开路队",
+            "6-4e点击指挥部0"
+        ]
+    },
+    "6-4e部署开路队":{
+        "recognition": "OCR",
+        "roi" : [1141,612,86,50],
+        "expected":"确定",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":200,
+        "target" : [1141,612,86,50],
+        "post_delay":400,
+        "next":[
+            "6-4e开始作战"
+        ]
+    },
+    "6-4e开始作战":{
+        "recognition": "OCR",
+        "roi" : [1042,624,88,45],
+        "expected":"开始",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1040,629,179,61],
+        "post_delay": 400,
+        "next":[
+            "6-4e选中开路队"
+        ]
+    },
+    "6-4e选中开路队":{
+        "recognition": "TemplateMatch",
+        "roi" : [986,620,91,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数02.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [256,689,18,18],
+        "post_delay": 400,
+        "next":[
+            "6-4e选中开路队",
+            "6-4e确认选中开路队"
+        ]
+    },
+    "6-4e确认选中开路队":{
+        "recognition": "OCR",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1141,614,88,48],
+        "post_delay": 400,
+        "next":[
+            "6-4e开路队向前一步"
+        ]
+    },
+    "6-4e开路队向前一步":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [271,622,18,18],
+        "post_delay": 1200,
+        "next":[
+            "6-4e点击指挥部1"
+        ]
+    },
+    "6-4e点击指挥部1":{
+        "recognition": "TemplateMatch",
+        "roi" : [980,620,101,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数01.png",
+        "pre_delay":1000,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [256,689,18,24],
+        "post_delay": 200,
+        "next":[
+            "6-4e部署狗粮队"
+        ]
+    },
+    "6-4e部署狗粮队":{
+        "recognition": "OCR",
+        "roi" : [559,417,86,43],
+        "expected":"部署",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [559,417,86,43],
+        "post_delay": 200,
+        "next":[
+            "6-4e确认部署狗粮队"
+        ]
+    },
+    "6-4e确认部署狗粮队":{
+        "recognition": "OCR",
+        "roi" : [1141,612,86,50],
+        "expected":"确定",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":300,
+        "target" : [1141,612,86,50],
+        "post_delay": 400,
+        "next":[
+            "6-4e结束第一回合"
+        ]
+    },
+    "6-4e结束第一回合":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,618,99,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1118,640,120,45],
+        "post_wait_freezes":3000,
+        "next":[
+            "6-4e-Round2-选中开路队"
+        ]
+    },
+    "6-4e-Round2-选中开路队":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,619,99,100],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数03.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [274,618,13,17],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-选中开路队",
+            "6-4e-Round2-确认选中开路队"
+        ]
+    },
+    "6-4e-Round2-确认选中开路队":{
+        "recognition": "OCR",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1141,614,88,48],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-开路队向前一步"
+        ]
+    },
+    "6-4e-Round2-开路队向前一步":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [320,544,16,16],
+        "post_delay": 8000,
+        "next":[
+            "6-4e-Round2-开路队结算"
+        ]
+    },
+    "6-4e-Round2-开路队结算":{
+        "recognition": "OCR",
+        "roi" : [964,359,45,27],
+        "expected": [
+            "歼灭"
+        ],
+        "rate_limit": 500,
+        "action": "LongPress",
+        "duration": 10,
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "post_delay": 1,
+        "pre_delay": 500,
+        "next": [
+            "6-4e-Round2-加速结算点击1"
+        ]
+    },
+    "6-4e-Round2-加速结算点击1": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "post_delay": 1,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "next": [
+            "6-4e-Round2-加速结算点击2"
+        ]
+    },
+    "6-4e-Round2-加速结算点击2": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "post_delay": 1,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "next": [
+            "6-4e-Round2-加速结算点击3"
+        ]
+    },
+    "6-4e-Round2-加速结算点击3": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "post_delay": 1,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "next": [
+            "6-4e-Round2-加速结算点击4"
+        ]
+    },
+    "6-4e-Round2-加速结算点击4": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "post_delay": 5000,
+        "next": [
+            "6-4e-Round2-选中狗粮队"
+        ]
+    },
+
+
+    "6-4e-Round2-选中狗粮队":{
+        "recognition": "TemplateMatch",
+        "roi" : [986,620,91,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数02.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [257,692,14,17],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-选中狗粮队",
+            "6-4e-Round2-确认选中狗粮队"
+        ]
+    },
+    "6-4e-Round2-确认选中狗粮队":{
+        "recognition": "OCR",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1141,614,88,48],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-狗粮队向前一步"
+        ]
+    },
+    "6-4e-Round2-狗粮队向前一步":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [272,624,16,16],
+        "post_delay": 1200,
+        "next":[
+           "6-4e-Round2-点击指挥部0"
+        ]
+    },
+    "6-4e-Round2-点击指挥部0":{
+        "recognition": "TemplateMatch",
+        "roi" : [980,620,101,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数01.png",
+        "pre_delay":500,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [256,689,18,24],
+        "post_delay": 1000,
+        "next":[
+            "6-4e-Round2-部署打捞队"
+        ]
+    },
+    "6-4e-Round2-部署打捞队":{
+        "recognition": "OCR",
+        "roi" : [559,417,86,43],
+        "expected":"部署",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [559,417,86,43],
+        "post_delay": 200,
+        "next":[
+            "6-4e-Round2-确认部署打捞队"
+        ]
+    },
+    "6-4e-Round2-确认部署打捞队":{
+        "recognition": "OCR",
+        "roi" : [1141,612,86,50],
+        "expected":"确定",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":300,
+        "target" : [1141,612,86,50],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-选中打捞队"
+        ]
+    },
+    "6-4e-Round2-选中打捞队":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,618,99,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [472,425,16,16],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-选中打捞队",
+            "6-4e-Round2-确认选中打捞队"
+        ]
+    },
+     "6-4e-Round2-确认选中打捞队":{
+        "recognition": "OCR",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1141,614,88,48],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-点击狗粮队"
+        ]
+
+     },
+    "6-4e-Round2-点击狗粮队":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [489,356,16,16],
+        "next":[
+            "6-4e-Round2-打捞狗粮换位"
+        ]
+    },
+    "6-4e-Round2-打捞狗粮换位":{
+        "recognition": "OCR",
+        "roi" : [335,344,79,45],
+        "expected":"换位",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "post_wait_freezes":1000,
+        "target" : [335,344,79,45],
+        "next":[
+            "6-4e-Round2-结束第二回合"
+        ]
+    },
+    "6-4e-Round2-结束第二回合":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,618,99,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
+        "pre_delay":800,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1118,640,120,45],
+        "post_delay":5000,
+        "next":[
+            "6-4e-Round2结束-开路队结算"
+        ]
+    },
+    "6-4e-Round2结束-开路队结算":{
+        "recognition": "OCR",
+        "roi" : [964,359,45,27],
+        "expected": [
+            "歼灭"
+        ],
+        "rate_limit": 500,
+        "action": "LongPress",
+        "duration": 10,
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "post_delay": 1,
+        "pre_delay": 500,
+        "next": [
+            "6-4e-Round2结束-加速结算点击1"
+        ]
+    },
+    "6-4e-Round2结束-加速结算点击1": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "post_delay": 1,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "next": [
+            "6-4e-Round2结束-加速结算点击2"
+        ]
+    },
+    "6-4e-Round2结束-加速结算点击2": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "post_delay": 1,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "next": [
+            "6-4e-Round2结束-加速结算点击3"
+        ]
+    },
+    "6-4e-Round2结束-加速结算点击3": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "post_delay": 1,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "next": [
+            "6-4e-Round2结束-加速结算点击4"
+        ]
+    },
+    "6-4e-Round2结束-加速结算点击4": {
+        "target": [
+            372,
+            615,
+            80,
+            21
+        ],
+        "rate_limit": 20,
+        "pre_delay": 1,
+        "action": "LongPress",
+        "duration": 5,
+        "post_delay":5000,
+        "next": [
+            "6-4e-Round3-选中开路队"
+        ]
+    },
+    "6-4e-Round3-选中开路队":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,620,98,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数04.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [320,542,16,16],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round3-选中开路队",
+            "6-4e-Round3-确认选中开路队"
+        ]
+    },
+    "6-4e-Round3-确认选中开路队":{
+        "recognition": "OCR",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1141,614,88,48],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round3-点击计划模式"
+        ]
+    },
+    "6-4e-Round3-点击计划模式":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [32,619,73,23],
+        "next":[
+            "6-4e-Round3-开路-计划2步"
+        ]
+    },
+    "6-4e-Round3-开路-计划2步":{
+        "recognition": "TemplateMatch",
+        "roi" : [984,620,104,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数4.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [396,411,18,14],
+        "post_wait_freezes":400,
+        "next":[
+            "6-4e-Round3-选中打捞队"
+        ]
+    },
+    "6-4e-Round3-选中打捞队":{
+        "recognition": "TemplateMatch",
+        "roi" : [983,620,106,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [273,618,19,19],
+        "post_wait_freezes":400,
+        "next":[
+            "6-4e-Round3-确认选择打捞队"
+        ]
+    },
+    "6-4e-Round3-确认选择打捞队":{
+        "recognition": "OCR",
+        "roi" : [364,610,83,39],
+        "expected":"选择",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [370,613,70,35],
+        "post_wait_freezes":400,
+        "next":[
+            "6-4e-Round3-打捞-计划3步"
+        ]
+    },
+    "6-4e-Round3-打捞-计划3步":{
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [396,411,18,14],
+        "post_wait_freezes":400,
+         "next":[
+            "6-4e-Round3-执行计划"
+        ]
+    },
+    "6-4e-Round3-执行计划":{
+        "recognition": "TemplateMatch",
+        "roi" : [982,622,106,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-1.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1112,638,104,52],
+        "post_delay":30000,
+        "post_wait_freezes":3000,
+        "next":[
+            "6-4e-Round3-结束第三回合"
+        ]
+    },
+    "6-4e-Round3-结束第三回合":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":1000,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1118,640,120,45],
+        "post_delay":20000,
+        "post_wait_freezes":10000,
+        "doc":"等待第三回合结束，第四回合开始",
+        "next":[
+            "6-4e-Round4-地图纵向调整"
+        ]
+    },
+    "6-4e-Round4-地图纵向调整":{
+        "pre_delay":200,
+        "action": "Swipe",
+        "begin" : [1179,372,1,1],
+        "end" : [1179,396,1,1],
+        "duration":600,
+        "post_delay":1000,
+        "next":[
+            "6-4e-Round4-纵向调整到位",
+            "6-4e-Round4-地图纵向调整"
+        ]
+    },
+     "6-4e-Round4-纵向调整到位":{
+        "recognition": "ColorMatch",
+        "roi" : [862,698,33,22],
+        "method" : 4,
+        "upper" : [235,235,235],
+        "lower" : [209,209,209],
+        "count": 400,
+        "connected":true,
+        "next":[
+            "6-4e-Round4-地图横向调整"
+        ]
+     },
+     "6-4e-Round4-地图横向调整":{
+        "pre_delay":200,
+        "action": "Swipe",
+        "begin" : [1179,372,1,1],
+        "end" : [1083,372,1,1],
+        "duration":600,
+        "post_delay":1500,
+
+        "next":[
+            "6-4e-Round4-横向调整到位",
+            "6-4e-Round4-地图横向调整"
+            
+        ]
+     },
+     "6-4e-Round4-横向调整到位":{
+        "recognition": "ColorMatch",
+        "roi" : [650,699,25,21],
+        "method" : 4,
+        "upper" : [237,237,237],
+        "lower" : [212,212,212],
+        "count": 300,
+        "connected":true,
+        "post_wait_freezes":4000,
+        "next":[
+            "6-4e-Round4-选中打捞队"
+        ]
+     },
+     "6-4e-Round4-选中打捞队":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,620,98,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数04.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [403,411,13,14],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-选中打捞队",
+            "6-4e-Round4-确认选中打捞队"
+        ]
+     },
+     "6-4e-Round4-确认选中打捞队":{
+        "recognition": "OCR",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":800,
+        "target" : [1141,614,88,48],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-计划模式"
+        ]
+     },
+     "6-4e-Round4-计划模式":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [32,619,73,23],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-打捞-计划2步至左2机场"
+        ]
+     },
+     "6-4e-Round4-打捞-计划2步至左2机场":{
+        "recognition": "TemplateMatch",
+        "roi" : [984,620,104,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数4.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [330,228,17,16],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-点击开路队"
+        ]
+     },
+     "6-4e-Round4-点击开路队":{
+        "recognition": "TemplateMatch",
+        "roi" : [983,620,106,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [401,480,14,16],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-选择开路队"
+        ]
+     },
+      "6-4e-Round4-选择开路队":{
+        "recognition": "OCR",
+        "roi" : [489,470,81,41],
+        "expected":"选择",
+        "pre_delay":800,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [489,470,81,41],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-开路-计划2步至8993普通点"
+        ]
+      },
+      "6-4e-Round4-开路-计划2步至8993普通点":{
+        "recognition": "TemplateMatch",
+        "roi" : [983,620,106,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [400,318,14,16],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-点击打捞队"
+        ]
+      },
+      "6-4e-Round4-点击打捞队":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,618,109,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数0.png",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [400,405,16,18],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-选择打捞队"
+        ]
+      },
+      "6-4e-Round4-选择打捞队":{
+        "recognition": "OCR",
+        "roi" : [493,399,81,41],
+        "expected":"选择",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [493,399,81,41],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-打捞-计划1步至左1boss"
+        ]
+      },
+      "6-4e-Round4-打捞-计划1步至左1boss":{
+        "recognition": "TemplateMatch",
+        "roi" : [981,618,109,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数0.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [214,129,14,15],
+        "post_delay":500,
+        "next":[
+            "6-4e-Round4-打捞-计划3步至左3boss"
+        ]
+      },
+      "6-4e-Round4-打捞-计划3步至左3boss":{
+        "recognition": "TemplateMatch",
+        "roi" : [982,622,106,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-1.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [504,167,14,15],
+        "post_delay":500,
+        "next":[
+            "6-4e-Round4-点击开路队1"
+        ]
+      },
+      "6-4e-Round4-点击开路队1":{
+        "recognition": "TemplateMatch",
+        "roi" : [974,617,115,102],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-4.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [401,480,14,16],
+        "post_delay":500,
+        "next":[
+            "6-4e-Round4-选择开路队1"
+        ]
+      },
+      "6-4e-Round4-选择开路队1":{
+        "recognition": "OCR",
+        "roi" : [489,470,81,41],
+        "expected":"选择",
+        "pre_delay":800,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [489,470,81,41],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-开路-计划2步至左2boss"
+        ]
+      },
+      "6-4e-Round4-开路-计划2步至左2boss":{
+        "recognition": "TemplateMatch",
+        "roi" : [974,617,115,102],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-4.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [367,158,15,14],
+        "post_delay":500,
+        "next":[
+            "6-4e-Round4-点击打捞队1"
+        ]
+      },
+      "6-4e-Round4-点击打捞队1":{
+        "recognition": "TemplateMatch",
+        "roi" : [982,622,106,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-6.png",
+        "pre_delay":800,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [400,407,15,17],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-选择打捞队1"
+        ]
+      },
+      "6-4e-Round4-选择打捞队1":{
+        "recognition": "OCR",
+        "roi" : [493,399,81,41],
+        "expected":"选择",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [493,399,81,41],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-打捞-计划3步至右1boss"
+        ]
+      },
+      "6-4e-Round4-打捞-计划3步至右1boss":{
+        "recognition": "TemplateMatch",
+        "roi" : [982,622,106,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-6.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [894,116,14,15],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-打捞-计划8步至未占领机场"
+        ]
+      },
+      "6-4e-Round4-打捞-计划8步至未占领机场":{
+        "recognition": "TemplateMatch",
+        "roi" : [983,619,107,100],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-9.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [821,636,18,17],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-打捞-计划5步至敌方指挥部"
+        ]
+      },
+      "6-4e-Round4-打捞-计划5步至敌方指挥部":{
+        "recognition": "TemplateMatch",
+        "roi" : [968,620,123,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-17.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [480,695,12,16],
+        "post_wait_freezes":500,
+        "next":[
+            "6-4e-Round4-打捞-计划2步至白色普通点"
+        ]
+      },
+      "6-4e-Round4-打捞-计划2步至白色普通点":{
+        "recognition": "TemplateMatch",
+        "roi" : [972,620,116,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-21.png",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [657,703,15,16],
+        "post_wait_freezes":800,
+        "next":[
+            "6-4e-Round4-执行计划"
+        ]
+      },
+      "6-4e-Round4-执行计划":{
+        "recognition": "TemplateMatch",
+        "roi" : [970,623,118,96],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-23.png",
+        "pre_delay":800,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1113,640,104,47],
+        "post_delay": 300000,
+        "next":[
+            "6-4e-点击再次作战"
+        ]
+      },
+      "6-4e-点击再次作战":{
+        "recognition": "OCR",
+        "roi": [277,572,188,73],
+        "expected": [
+            "再次作战"
+        ],
+        "action": "LongPress",
+        "duration": 20,
+        "post_delay": 800,
+        "rate_limit": 1200,
+        "target": [318,614,130,24],
+        "next":[
+            "6-4e开始作战"
+        ],
+        "interrupt": [
+            "public拆人形_人形回收",
+            "6-4e-点击获得角色"
+        ]
+    },
+    "6-4e-点击获得角色": {
+        "recognition": "DirectHit",
+        "action": "LongPress",
+        "duration": 20,
+        "target": [
+            386,
+            620,
+            1,
+            1
+        ],
+        "pre_delay": 100,
+        "timeout": 300000
+    }
+      
+}


### PR DESCRIPTION
使用6-4e圣捞请在设置中打开自动补给，关闭战场信息
梯队部署顺序为
1队开路队
2队狗粮队
3队打捞队，需要连斩boss，无锁血前排人形请使用高闪避前排人形
3队均需携带任意妖精
将地图缩放至最小，并让我方指挥部与下边界、敌方单位计数栏相切，与布局要求图相同即可开启脚本食用
<img width="605" height="202" alt="布局要求" src="https://github.com/user-attachments/assets/cd1dfdd9-1d50-457e-8c1c-7983b1d61a57" />
<img width="722" height="367" alt="配队示例" src="https://github.com/user-attachments/assets/8477550e-50f7-4ca7-bd0e-08f5ce38b018" />
