### PR TITLE
重构6-4e圣捞

### DIFF
--- a/assets/resource/pipeline/tasks/combat/dollRescue/residentRescue/6-4eRescue.json
+++ b/assets/resource/pipeline/tasks/combat/dollRescue/residentRescue/6-4eRescue.json
@@ -1,1541 +1,880 @@
 {
-    "!6-4e打捞总流程": {
-        "next": [
+    "!6-4e打捞总流程":{
+        "next":[
             "6-4e点击指挥部0"
         ]
     },
-    "6-4e点击指挥部0": {
+    "6-4e点击指挥部0":{
         "recognition": "OCR",
-        "roi": [
-            1043,
-            666,
-            96,
-            28
-        ],
-        "expected": "点击指挥部",
+        "roi" : [1043,666,96,28],
+        "expected":"点击指挥部",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            256,
-            689,
-            18,
-            24
-        ],
-        "post_delay": 200,
+        "target" : [472,429,16,16],
+        "post_delay":200,
         "next": [
             "6-4e部署开路队",
-            "6-4e点击指挥部0"
+            "6-4e已部署开路队"
         ]
     },
-    "6-4e部署开路队": {
+    "6-4e部署开路队":{
         "recognition": "OCR",
-        "roi": [
-            1141,
-            612,
-            86,
-            50
-        ],
-        "expected": "确定",
+        "roi" : [1141,612,86,50],
+        "expected":"确定",
         "action": "LongPress",
         "duration": 20,
-        "pre_delay": 200,
-        "target": [
-            1141,
-            612,
-            86,
-            50
-        ],
-        "post_delay": 400,
-        "next": [
+        "pre_delay":200,
+        "target" : [1141,612,86,50],
+        "post_delay":400,
+        "next":[
             "6-4e开始作战"
         ]
     },
-    "6-4e开始作战": {
+    "6-4e已部署开路队":{
         "recognition": "OCR",
-        "roi": [
-            1042,
-            624,
-            88,
-            45
-        ],
-        "expected": "开始",
+        "roi" : [1141,612,86,50],
+        "expected":"取消",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            1040,
-            629,
-            179,
-            61
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e选中开路队"
+        "pre_delay":200,
+        "target" : [1141,612,86,50],
+        "post_delay":400,
+        "next":[
+            "6-4e开始作战"
         ]
     },
-    "6-4e选中开路队": {
+    "6-4e开始作战":{
+        "recognition": "OCR",
+        "roi" : [1042,624,88,45],
+        "expected":"开始",
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1040,629,179,61],
+        "post_delay": 400,
+        "next":[
+            "6-4e点击开路队"
+        ]
+    },
+    "6-4e点击开路队":{
         "recognition": "TemplateMatch",
-        "roi": [
-            986,
-            620,
-            91,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数02.png",
+        "roi" : [986,620,91,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数02.png",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            256,
-            689,
-            18,
-            18
-        ],
+        "target" : [472,429,16,16],
         "post_delay": 400,
-        "next": [
-            "6-4e选中开路队",
-            "6-4e确认选中开路队"
+        "next":[
+            "6-4e点击开路队",
+            "6-4e补给开路队"
         ]
     },
-    "6-4e确认选中开路队": {
+    "6-4e补给开路队":{
         "recognition": "OCR",
-        "roi": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "expected": "取消",
+        "roi" : [1160,534,88,53],
+        "expected":"补给",
         "action": "LongPress",
         "duration": 20,
-        "pre_delay": 400,
-        "target": [
-            1141,
-            614,
-            88,
-            48
-        ],
+        "pre_delay":400,
+        "target" : [1160,534,88,53],
         "post_delay": 400,
-        "next": [
+        "next":[
             "6-4e开路队向前一步"
         ]
     },
-    "6-4e开路队向前一步": {
+    "6-4e开路队向前一步":{
         "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 400,
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            271,
-            622,
-            18,
-            18
-        ],
-        "post_delay": 1200,
-        "next": [
+        "target" : [490,360,12,12],
+        "post_delay": 2000,
+        "next":[
             "6-4e点击指挥部1"
         ]
     },
-    "6-4e点击指挥部1": {
+    "6-4e点击指挥部1":{
         "recognition": "TemplateMatch",
-        "roi": [
-            980,
-            620,
-            101,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数01.png",
-        "pre_delay": 1000,
+        "roi" : [986,620,92,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数01.png",
+        "pre_delay":600,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            256,
-            689,
-            18,
-            24
-        ],
+        "target" : [474,430,14,14],
         "post_delay": 200,
-        "next": [
+        "next":[
             "6-4e部署狗粮队"
         ]
     },
-    "6-4e部署狗粮队": {
+    "6-4e部署狗粮队":{
         "recognition": "OCR",
-        "roi": [
-            559,
-            417,
-            86,
-            43
-        ],
-        "expected": "部署",
-        "pre_delay": 400,
+        "roi" : [559,417,86,43],
+        "expected":"部署",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            559,
-            417,
-            86,
-            43
-        ],
+        "target" : [559,417,86,43],
         "post_delay": 200,
-        "next": [
+        "next":[
             "6-4e确认部署狗粮队"
         ]
     },
-    "6-4e确认部署狗粮队": {
+    "6-4e确认部署狗粮队":{
         "recognition": "OCR",
-        "roi": [
-            1141,
-            612,
-            86,
-            50
-        ],
-        "expected": "确定",
+        "roi" : [1141,612,86,50],
+        "expected":"确定",
         "action": "LongPress",
         "duration": 20,
-        "pre_delay": 300,
-        "target": [
-            1141,
-            612,
-            86,
-            50
-        ],
+        "pre_delay":300,
+        "target" : [1141,612,86,50],
         "post_delay": 400,
-        "next": [
+        "next":[
             "6-4e结束第一回合"
         ]
     },
-    "6-4e结束第一回合": {
+    "6-4e结束第一回合":{
         "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            618,
-            99,
-            101
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
-        "pre_delay": 400,
+        "roi" : [981,618,99,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            1118,
-            640,
-            120,
-            45
-        ],
-        "post_wait_freezes": 3000,
-        "next": [
+        "target" : [1118,640,120,45],
+        "post_delay":12000,
+        "next":[
             "6-4e-Round2-选中开路队"
         ]
     },
-    "6-4e-Round2-选中开路队": {
+    "6-4e-Round2-选中开路队":{
         "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            619,
-            99,
-            100
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数03.png",
-        "pre_delay": 400,
+        "roi" : [415,3,61,80],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/回合02.png",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            274,
-            618,
-            13,
-            17
-        ],
+        "target" : [490,360,12,12],
         "post_delay": 400,
-        "next": [
-            "6-4e-Round2-选中开路队",
-            "6-4e-Round2-确认选中开路队"
+        "next":[
+            "6-4e-Round2-确认选中开路队",
+            "6-4e-Round2-点击计划模式",
+            "6-4e-Round2-选中开路队"
         ]
     },
-    "6-4e-Round2-确认选中开路队": {
+    "6-4e-Round2-确认选中开路队":{
         "recognition": "OCR",
-        "roi": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "expected": "取消",
+        "roi" : [1141,614,88,48],
+        "expected":"取消",
         "action": "LongPress",
         "duration": 20,
-        "pre_delay": 400,
-        "target": [
-            1141,
-            614,
-            88,
-            48
-        ],
+        "pre_delay":400,
+        "target" : [1141,614,88,48],
         "post_delay": 400,
-        "next": [
-            "6-4e-Round2-开路队向前一步"
+        "next":[
+            "6-4e-Round2-点击计划模式"
         ]
     },
-    "6-4e-Round2-开路队向前一步": {
+    "6-4e-Round2-点击计划模式":{
         "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 400,
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            320,
-            544,
-            16,
-            16
-        ],
-        "post_delay": 8000,
-        "next": [
-            "6-4e-Round2-开路队结算"
+        "pre_delay":400,
+        "target" : [31,616,73,28],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-开路队-计划1步"
         ]
     },
-    "6-4e-Round2-开路队结算": {
-        "recognition": "OCR",
-        "roi": [
-            964,
-            359,
-            45,
-            27
-        ],
-        "expected": [
-            "歼灭"
-        ],
-        "rate_limit": 500,
-        "action": "LongPress",
-        "duration": 10,
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "post_delay": 1,
-        "pre_delay": 500,
-        "next": [
-            "6-4e-Round2-加速结算点击1"
-        ]
-    },
-    "6-4e-Round2-加速结算点击1": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "post_delay": 1,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "next": [
-            "6-4e-Round2-加速结算点击2"
-        ]
-    },
-    "6-4e-Round2-加速结算点击2": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "post_delay": 1,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "next": [
-            "6-4e-Round2-加速结算点击3"
-        ]
-    },
-    "6-4e-Round2-加速结算点击3": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "post_delay": 1,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "next": [
-            "6-4e-Round2-加速结算点击4"
-        ]
-    },
-    "6-4e-Round2-加速结算点击4": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "post_delay": 5000,
-        "next": [
-            "6-4e-Round2-选中狗粮队"
-        ]
-    },
-    "6-4e-Round2-选中狗粮队": {
+    "6-4e-Round2-开路队-计划1步":{
         "recognition": "TemplateMatch",
-        "roi": [
-            986,
-            620,
-            91,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数02.png",
-        "pre_delay": 200,
+        "roi" : [987,617,100,102],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数3.png",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            257,
-            692,
-            14,
-            17
-        ],
+        "pre_delay":400,
+        "target" : [535,278,18,15],
         "post_delay": 400,
-        "next": [
-            "6-4e-Round2-选中狗粮队",
-            "6-4e-Round2-确认选中狗粮队"
-        ]
-    },
-    "6-4e-Round2-确认选中狗粮队": {
-        "recognition": "OCR",
-        "roi": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "expected": "取消",
-        "action": "LongPress",
-        "duration": 20,
-        "pre_delay": 400,
-        "target": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e-Round2-狗粮队向前一步"
-        ]
-    },
-    "6-4e-Round2-狗粮队向前一步": {
-        "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 400,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            272,
-            624,
-            16,
-            16
-        ],
-        "post_delay": 1200,
-        "next": [
-            "6-4e-Round2-点击指挥部0"
-        ]
-    },
-    "6-4e-Round2-点击指挥部0": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            980,
-            620,
-            101,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数01.png",
-        "pre_delay": 500,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            256,
-            689,
-            18,
-            24
-        ],
-        "post_delay": 1000,
-        "next": [
-            "6-4e-Round2-部署打捞队"
-        ]
-    },
-    "6-4e-Round2-部署打捞队": {
-        "recognition": "OCR",
-        "roi": [
-            559,
-            417,
-            86,
-            43
-        ],
-        "expected": "部署",
-        "pre_delay": 400,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            559,
-            417,
-            86,
-            43
-        ],
-        "post_delay": 200,
-        "next": [
-            "6-4e-Round2-确认部署打捞队"
-        ]
-    },
-    "6-4e-Round2-确认部署打捞队": {
-        "recognition": "OCR",
-        "roi": [
-            1141,
-            612,
-            86,
-            50
-        ],
-        "expected": "确定",
-        "action": "LongPress",
-        "duration": 20,
-        "pre_delay": 300,
-        "target": [
-            1141,
-            612,
-            86,
-            50
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e-Round2-选中打捞队"
-        ]
-    },
-    "6-4e-Round2-选中打捞队": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            618,
-            99,
-            101
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
-        "action": "LongPress",
-        "duration": 20,
-        "pre_delay": 400,
-        "target": [
-            472,
-            425,
-            16,
-            16
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e-Round2-选中打捞队",
-            "6-4e-Round2-确认选中打捞队"
-        ]
-    },
-    "6-4e-Round2-确认选中打捞队": {
-        "recognition": "OCR",
-        "roi": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "expected": "取消",
-        "action": "LongPress",
-        "duration": 20,
-        "pre_delay": 400,
-        "target": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "post_delay": 400,
-        "next": [
+        "next":[
             "6-4e-Round2-点击狗粮队"
         ]
     },
-    "6-4e-Round2-点击狗粮队": {
+    "6-4e-Round2-点击狗粮队":{
         "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 400,
+        "roi" : [1112,532,72,37],
+        "expected" : "下一",
+        "pre_delay":200,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            489,
-            356,
-            16,
-            16
-        ],
-        "next": [
-            "6-4e-Round2-打捞狗粮换位"
+        "target" : [472,427,16,16],
+        "post_delay": 500,
+        "next":[
+            "6-4e-Round2-选择狗粮队"
         ]
     },
-    "6-4e-Round2-打捞狗粮换位": {
+    "6-4e-Round2-选择狗粮队":{
         "recognition": "OCR",
-        "roi": [
-            335,
-            344,
-            79,
-            45
-        ],
-        "expected": "换位",
-        "pre_delay": 200,
+        "roi" : [563,418,81,40],
+        "expected" : "选择",
+        "pre_delay":200,
         "action": "LongPress",
         "duration": 20,
-        "post_wait_freezes": 1000,
-        "target": [
-            335,
-            344,
-            79,
-            45
-        ],
-        "next": [
-            "6-4e-Round2-结束第二回合"
+        "target" : [563,418,81,40],
+        "post_delay": 500,
+        "next":[
+           "6-4e-Round2-计划移动狗粮"
         ]
     },
-    "6-4e-Round2-结束第二回合": {
+    "6-4e-Round2-计划移动狗粮":{
         "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            618,
-            99,
-            101
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
-        "pre_delay": 800,
+        "roi" : [983,620,106,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            1118,
-            640,
-            120,
-            45
-        ],
-        "post_delay": 5000,
-        "next": [
-            "6-4e-Round2结束-开路队结算"
-        ]
-    },
-    "6-4e-Round2结束-开路队结算": {
-        "recognition": "OCR",
-        "roi": [
-            964,
-            359,
-            45,
-            27
-        ],
-        "expected": [
-            "歼灭"
-        ],
-        "rate_limit": 500,
-        "action": "LongPress",
-        "duration": 10,
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "post_delay": 1,
-        "pre_delay": 500,
-        "next": [
-            "6-4e-Round2结束-加速结算点击1"
-        ]
-    },
-    "6-4e-Round2结束-加速结算点击1": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "post_delay": 1,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "next": [
-            "6-4e-Round2结束-加速结算点击2"
-        ]
-    },
-    "6-4e-Round2结束-加速结算点击2": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "post_delay": 1,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "next": [
-            "6-4e-Round2结束-加速结算点击3"
-        ]
-    },
-    "6-4e-Round2结束-加速结算点击3": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "post_delay": 1,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "next": [
-            "6-4e-Round2结束-加速结算点击4"
-        ]
-    },
-    "6-4e-Round2结束-加速结算点击4": {
-        "target": [
-            372,
-            615,
-            80,
-            21
-        ],
-        "rate_limit": 20,
-        "pre_delay": 1,
-        "action": "LongPress",
-        "duration": 5,
-        "post_delay": 5000,
-        "next": [
-            "6-4e-Round3-选中开路队"
-        ]
-    },
-    "6-4e-Round3-选中开路队": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            620,
-            98,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数04.png",
-        "pre_delay": 400,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            320,
-            542,
-            16,
-            16
-        ],
+        "target" : [488,358,15,14],
         "post_delay": 400,
-        "next": [
-            "6-4e-Round3-选中开路队",
-            "6-4e-Round3-确认选中开路队"
+        "next":[
+            "6-4e-Round2-狗粮点击移动按钮"
         ]
     },
-    "6-4e-Round3-确认选中开路队": {
+    "6-4e-Round2-狗粮点击移动按钮":{
         "recognition": "OCR",
-        "roi": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "expected": "取消",
+        "roi" : [332,346,80,42],
+        "expected":"移动",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "pre_delay": 400,
-        "target": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e-Round3-点击计划模式"
+        "target" : [332,346,80,42],
+        "post_delay": 800,
+        "next":[
+           "6-4e-Round2-执行计划1"
         ]
     },
-    "6-4e-Round3-点击计划模式": {
-        "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 400,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            32,
-            619,
-            73,
-            23
-        ],
-        "next": [
-            "6-4e-Round3-开路-计划2步"
-        ]
-    },
-    "6-4e-Round3-开路-计划2步": {
+    "6-4e-Round2-执行计划1":{
         "recognition": "TemplateMatch",
-        "roi": [
-            984,
-            620,
-            104,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数4.png",
+        "roi" : [984,620,105,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数1.png",
+        "pre_delay":500,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            396,
-            411,
-            18,
-            14
-        ],
-        "post_wait_freezes": 400,
-        "next": [
-            "6-4e-Round3-选中打捞队"
-        ]
-    },
-    "6-4e-Round3-选中打捞队": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            983,
-            620,
-            106,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            273,
-            618,
-            19,
-            19
-        ],
-        "post_wait_freezes": 400,
-        "next": [
-            "6-4e-Round3-确认选择打捞队"
-        ]
-    },
-    "6-4e-Round3-确认选择打捞队": {
-        "recognition": "OCR",
-        "roi": [
-            364,
-            610,
-            83,
-            39
-        ],
-        "expected": "选择",
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            370,
-            613,
-            70,
-            35
-        ],
-        "post_wait_freezes": 400,
-        "next": [
-            "6-4e-Round3-打捞-计划3步"
-        ]
-    },
-    "6-4e-Round3-打捞-计划3步": {
-        "pre_delay": 400,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            396,
-            411,
-            18,
-            14
-        ],
-        "post_wait_freezes": 400,
-        "next": [
-            "6-4e-Round3-执行计划"
-        ]
-    },
-    "6-4e-Round3-执行计划": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            982,
-            622,
-            106,
-            97
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-1.png",
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            1112,
-            638,
-            104,
-            52
-        ],
+        "target" : [1116,642,101,42],
         "post_delay": 30000,
-        "post_wait_freezes": 3000,
-        "next": [
-            "6-4e-Round3-结束第三回合"
+        "next":[
+           "6-4e-Round2-点击指挥部"
         ]
     },
-    "6-4e-Round3-结束第三回合": {
+    "6-4e-Round2-点击指挥部":{
         "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 1000,
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "pre_delay":500,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            1118,
-            640,
-            120,
-            45
-        ],
-        "post_delay": 20000,
-        "post_wait_freezes": 10000,
-        "doc": "等待第三回合结束，第四回合开始",
-        "next": [
-            "6-4e-Round4-地图纵向调整"
-        ]
-    },
-    "6-4e-Round4-地图纵向调整": {
-        "pre_delay": 200,
-        "action": "Swipe",
-        "begin": [
-            1179,
-            372,
-            1,
-            1
-        ],
-        "end": [
-            1179,
-            396,
-            1,
-            1
-        ],
-        "duration": 600,
+        "target" : [472,429,16,16],
         "post_delay": 1000,
-        "next": [
-            "6-4e-Round4-纵向调整到位",
-            "6-4e-Round4-地图纵向调整"
+        "next":[
+            "6-4e-Round2-部署打捞队"
         ]
     },
-    "6-4e-Round4-纵向调整到位": {
-        "recognition": "ColorMatch",
-        "roi": [
-            862,
-            698,
-            33,
-            22
-        ],
-        "method": 4,
-        "upper": [
-            235,
-            235,
-            235
-        ],
-        "lower": [
-            209,
-            209,
-            209
-        ],
-        "count": 400,
-        "connected": true,
-        "next": [
-            "6-4e-Round4-地图横向调整"
-        ]
-    },
-    "6-4e-Round4-地图横向调整": {
-        "pre_delay": 200,
-        "action": "Swipe",
-        "begin": [
-            1179,
-            372,
-            1,
-            1
-        ],
-        "end": [
-            1083,
-            372,
-            1,
-            1
-        ],
-        "duration": 600,
-        "post_delay": 1500,
-        "next": [
-            "6-4e-Round4-横向调整到位",
-            "6-4e-Round4-地图横向调整"
-        ]
-    },
-    "6-4e-Round4-横向调整到位": {
-        "recognition": "ColorMatch",
-        "roi": [
-            650,
-            699,
-            25,
-            21
-        ],
-        "method": 4,
-        "upper": [
-            237,
-            237,
-            237
-        ],
-        "lower": [
-            212,
-            212,
-            212
-        ],
-        "count": 300,
-        "connected": true,
-        "post_wait_freezes": 4000,
-        "next": [
-            "6-4e-Round4-选中打捞队"
-        ]
-    },
-    "6-4e-Round4-选中打捞队": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            620,
-            98,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/行动点数04.png",
-        "pre_delay": 400,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            403,
-            411,
-            13,
-            14
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e-Round4-选中打捞队",
-            "6-4e-Round4-确认选中打捞队"
-        ]
-    },
-    "6-4e-Round4-确认选中打捞队": {
+    "6-4e-Round2-部署打捞队":{
         "recognition": "OCR",
-        "roi": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "expected": "取消",
+        "roi" : [559,417,86,43],
+        "expected":"部署",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "pre_delay": 800,
-        "target": [
-            1141,
-            614,
-            88,
-            48
-        ],
-        "post_delay": 400,
-        "next": [
-            "6-4e-Round4-计划模式"
+        "target" : [559,417,86,43],
+        "post_delay": 200,
+        "next":[
+            "6-4e-Round2-确认部署打捞队"
         ]
     },
-    "6-4e-Round4-计划模式": {
+    "6-4e-Round2-确认部署打捞队":{
         "recognition": "OCR",
-        "roi": [
-            1161,
-            118,
-            46,
-            24
-        ],
-        "expected": "妖精",
-        "pre_delay": 400,
+        "roi" : [1141,612,86,50],
+        "expected":"确定",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            32,
-            619,
-            73,
-            23
-        ],
+        "pre_delay":300,
+        "target" : [1141,612,86,50],
         "post_delay": 400,
-        "next": [
-            "6-4e-Round4-打捞-计划2步至左2机场"
+        "next":[
+            "6-4e-Round2-点击打捞队"
         ]
     },
-    "6-4e-Round4-打捞-计划2步至左2机场": {
+    "6-4e-Round2-点击打捞队":{
         "recognition": "TemplateMatch",
-        "roi": [
-            984,
-            620,
-            104,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数4.png",
+        "roi" : [981,618,99,101],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/行动点数00.png",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            330,
-            228,
-            17,
-            16
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-点击开路队"
+        "pre_delay":400,
+        "target" : [472,425,16,16],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-补给打捞队",
+            "6-4e-Round2-点击打捞队"
         ]
     },
-    "6-4e-Round4-点击开路队": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            983,
-            620,
-            106,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            401,
-            480,
-            14,
-            16
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-选择开路队"
-        ]
-    },
-    "6-4e-Round4-选择开路队": {
+    "6-4e-Round2-补给打捞队":{
         "recognition": "OCR",
-        "roi": [
-            489,
-            470,
-            81,
-            41
-        ],
-        "expected": "选择",
-        "pre_delay": 800,
+        "roi" : [1160,534,88,53],
+        "expected":"补给",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            489,
-            470,
-            81,
-            41
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-开路-计划2步至8993普通点"
+        "pre_delay":400,
+        "target" : [1160,534,88,53],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-点击计划模式1"
         ]
     },
-    "6-4e-Round4-开路-计划2步至8993普通点": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            983,
-            620,
-            106,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数2.png",
+    "6-4e-Round2-点击计划模式1":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            400,
-            318,
-            14,
-            16
-        ],
-        "post_wait_freezes": 500,
-        "next": [
+        "pre_delay":400,
+        "target" : [31,616,73,28],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-点击开路队"
+        ]
+
+    },
+    "6-4e-Round2-点击开路队":{
+        "recognition": "TemplateMatch",
+        "roi" : [986,616,101,103],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数0.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [540,277,12,17],
+        "next":[
+            "6-4e-Round2-选择开路队"
+        ]
+    },
+    "6-4e-Round2-选择开路队":{
+        "recognition": "OCR",
+        "roi" : [630,268,81,42],
+        "expected":"选择",
+        "pre_delay":200,
+        "action": "LongPress",
+        "duration": 20,
+        "post_delay":500,
+        "target" : [630,268,81,42],
+        "next":[
+            "6-4e-Round2-开路队-计划2步"
+        ]
+    },
+    "6-4e-Round2-开路队-计划2步":{
+        "recognition": "TemplateMatch",
+        "roi" : [986,616,101,103],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数0.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [613,148,16,16],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round2-点击打捞队1"
+        ]
+    },
+    "6-4e-Round2-点击打捞队1":{
+        "recognition": "TemplateMatch",
+        "roi" : [980,622,108,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-2.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [475,427,14,14],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round2-选择打捞队1"
+        ]
+    },
+     "6-4e-Round2-选择打捞队1":{
+        "recognition": "OCR",
+        "roi" : [564,417,80,42],
+        "expected":"选择",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [564,417,80,42],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-打捞队-计划4步"
+        ]
+    },
+    "6-4e-Round2-打捞队-计划4步":{
+        "recognition": "TemplateMatch",
+        "roi" : [980,622,108,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-2.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [612,149,16,15],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-点击下一回合"
+        ]
+    },
+    "6-4e-Round2-点击下一回合":{
+        "recognition": "TemplateMatch",
+        "roi" : [980,622,107,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/计划点数-6.png",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1116,533,67,34],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round2-执行计划2"
+        ]
+    },
+    "6-4e-Round2-执行计划2":{
+        "recognition": "OCR",
+        "roi" : [988,532,74,37],
+        "expected":"取消",
+        "pre_delay":400,
+        "action": "LongPress",
+        "duration": 20,
+        "target" : [1119,640,95,48],
+        "post_delay":130000,
+        "next":[
             "6-4e-Round4-点击打捞队"
         ]
     },
-    "6-4e-Round4-点击打捞队": {
+    "6-4e-Round4-点击打捞队":{
         "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            618,
-            109,
-            101
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数0.png",
+        "roi" : [413,0,66,85],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/回合04.png",
         "action": "LongPress",
+        "pre_delay":1000,
+        "threshold":[0.9],
         "duration": 20,
-        "target": [
-            400,
-            405,
-            16,
-            18
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-选择打捞队"
+        "target" : [614,352,14,14],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round4-点击计划模式"
         ]
     },
-    "6-4e-Round4-选择打捞队": {
+     "6-4e-Round4-点击计划模式":{
         "recognition": "OCR",
-        "roi": [
-            493,
-            399,
-            81,
-            41
-        ],
-        "expected": "选择",
-        "pre_delay": 200,
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            493,
-            399,
-            81,
-            41
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-打捞-计划1步至左1boss"
+        "pre_delay":400,
+        "target" : [32,618,62,25],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round4-打捞队-计划2步"
         ]
     },
-    "6-4e-Round4-打捞-计划1步至左1boss": {
+    "6-4e-Round4-打捞队-计划2步":{
         "recognition": "TemplateMatch",
-        "roi": [
-            981,
-            618,
-            109,
-            101
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数0.png",
-        "pre_delay": 200,
+        "roi" : [990,622,97,97],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R4计划点数4.png",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            214,
-            129,
-            14,
-            15
-        ],
-        "post_delay": 500,
-        "next": [
-            "6-4e-Round4-打捞-计划3步至左3boss"
+        "target" : [543,166,16,16],
+        "post_delay":400,
+         "next":[
+            "6-4e-Round4-点击开路队"
         ]
     },
-    "6-4e-Round4-打捞-计划3步至左3boss": {
+    
+    "6-4e-Round4-点击开路队":{
         "recognition": "TemplateMatch",
-        "roi": [
-            982,
-            622,
-            106,
-            97
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-1.png",
-        "pre_delay": 200,
+        "roi" : [990,623,96,96],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R4计划点数2.png",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            504,
-            167,
-            14,
-            15
-        ],
-        "post_delay": 500,
-        "next": [
-            "6-4e-Round4-点击开路队1"
+        "target" : [613,422,14,14],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-选择开路队"
         ]
     },
-    "6-4e-Round4-点击开路队1": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            974,
-            617,
-            115,
-            102
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-4.png",
-        "pre_delay": 200,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            401,
-            480,
-            14,
-            16
-        ],
-        "post_delay": 500,
-        "next": [
-            "6-4e-Round4-选择开路队1"
-        ]
-    },
-    "6-4e-Round4-选择开路队1": {
+     "6-4e-Round4-选择开路队":{
         "recognition": "OCR",
-        "roi": [
-            489,
-            470,
-            81,
-            41
-        ],
-        "expected": "选择",
-        "pre_delay": 800,
+        "roi" : [703,412,82,43],
+        "expected":"选择",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            489,
-            470,
-            81,
-            41
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-开路-计划2步至左2boss"
+        "pre_delay":800,
+        "target" : [703,412,82,43],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-开路队-计划2步"
         ]
     },
-    "6-4e-Round4-开路-计划2步至左2boss": {
+    "6-4e-Round4-开路队-计划2步":{
         "recognition": "TemplateMatch",
-        "roi": [
-            974,
-            617,
-            115,
-            102
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-4.png",
-        "pre_delay": 200,
+        "roi" : [990,623,96,96],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R4计划点数2.png",
+        "pre_delay":400,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            367,
-            158,
-            15,
-            14
-        ],
-        "post_delay": 500,
-        "next": [
-            "6-4e-Round4-点击打捞队1"
+        "target" : [614,262,14,14],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-点击下一回合"
         ]
     },
-    "6-4e-Round4-点击打捞队1": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            982,
-            622,
-            106,
-            97
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-6.png",
-        "pre_delay": 800,
+    "6-4e-Round4-点击下一回合":{
+        "pre_delay":800,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            400,
-            407,
-            15,
-            17
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-选择打捞队1"
+        "target" : [1124,536,74,29],
+        "post_delay": 400,
+        "next":[
+             "6-4e-Round4-开路队-计划再进1步"
         ]
     },
-    "6-4e-Round4-选择打捞队1": {
+    "6-4e-Round4-开路队-计划再进1步":{
         "recognition": "OCR",
-        "roi": [
-            493,
-            399,
-            81,
-            41
-        ],
-        "expected": "选择",
-        "pre_delay": 200,
+        "roi" : [976,529,87,44],
+        "expected":"取消",
+        "pre_delay":800,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            493,
-            399,
-            81,
-            41
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-打捞-计划3步至右1boss"
+        "target" : [543,166,13,15],
+        "post_delay": 400,
+        "next":[
+            "6-4e-Round4-开路队-计划回退1步"
         ]
-    },
-    "6-4e-Round4-打捞-计划3步至右1boss": {
+     },
+    "6-4e-Round4-开路队-计划回退1步":{
         "recognition": "TemplateMatch",
-        "roi": [
-            982,
-            622,
-            106,
-            97
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-6.png",
-        "pre_delay": 200,
+        "roi" : [990,625,96,77],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R4计划点数-1.png",
+        "pre_delay":800,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            894,
-            116,
-            14,
-            15
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-打捞-计划8步至未占领机场"
-        ]
-    },
-    "6-4e-Round4-打捞-计划8步至未占领机场": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            983,
-            619,
-            107,
-            100
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-9.png",
-        "pre_delay": 200,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            821,
-            636,
-            18,
-            17
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-打捞-计划5步至敌方指挥部"
-        ]
-    },
-    "6-4e-Round4-打捞-计划5步至敌方指挥部": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            968,
-            620,
-            123,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-17.png",
-        "pre_delay": 200,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            480,
-            695,
-            12,
-            16
-        ],
-        "post_wait_freezes": 500,
-        "next": [
-            "6-4e-Round4-打捞-计划2步至白色普通点"
-        ]
-    },
-    "6-4e-Round4-打捞-计划2步至白色普通点": {
-        "recognition": "TemplateMatch",
-        "roi": [
-            972,
-            620,
-            116,
-            99
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-21.png",
-        "pre_delay": 200,
-        "action": "LongPress",
-        "duration": 20,
-        "target": [
-            657,
-            703,
-            15,
-            16
-        ],
-        "post_wait_freezes": 800,
-        "next": [
+        "target" : [613,260,15,14],
+        "post_delay": 400,
+        "next":[
             "6-4e-Round4-执行计划"
         ]
     },
-    "6-4e-Round4-执行计划": {
+    "6-4e-Round4-执行计划":{
         "recognition": "TemplateMatch",
-        "roi": [
-            970,
-            623,
-            118,
-            96
-        ],
-        "template": "combat/dollRescue/residentRescue/6-4eRescue/计划点数-23.png",
-        "pre_delay": 800,
+        "roi" : [988,625,98,78],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R4计划点数-2.png",
+        "pre_delay":800,
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            1113,
-            640,
-            104,
-            47
-        ],
-        "post_delay": 300000,
-        "next": [
-            "6-4e-点击再次作战"
+        "target" : [1112,641,108,43],
+        "post_delay": 130000,
+        "next":[
+            "6-4e-Round5-点击打捞队"
         ]
     },
-    "6-4e-点击再次作战": {
+    "6-4e-Round5-点击打捞队":{
         "recognition": "OCR",
-        "roi": [
-            277,
-            572,
-            188,
-            73
-        ],
-        "expected": [
-            "再次作战"
-        ],
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
         "action": "LongPress",
         "duration": 20,
-        "post_delay": 800,
-        "rate_limit": 1200,
-        "target": [
-            318,
-            614,
-            130,
-            24
-        ],
-        "next": [
+        "pre_delay":400,
+        "target" : [543,259,15,15],
+        "post_delay":400,
+         "next":[
+            "6-4e-Round5-选择打捞队"
+        ]
+    },
+    "6-4e-Round5-选择打捞队":{
+        "recognition": "OCR",
+        "roi" : [633,246,82,44],
+        "expected":"选择",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [633,246,82,44],
+        "post_delay":400,
+         "next":[
+            "6-4e-Round5-点击打捞队1"
+        ]
+    },
+    "6-4e-Round5-点击打捞队1":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [543,259,15,15],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-补给打捞队",
+            "6-4e-Round5-点击打捞队1"
+        ]
+    },
+    "6-4e-Round5-补给打捞队":{
+        "recognition": "OCR",
+        "roi" : [1161,535,88,53],
+        "expected":"补给",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1161,535,88,53],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-点击计划模式"
+        ]
+    },
+    "6-4e-Round5-点击计划模式":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [31,618,93,23],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-打捞队-左1机场"
+        ]
+    },
+    "6-4e-Round5-打捞队-左1机场":{
+        "recognition": "TemplateMatch",
+        "roi" : [990,624,100,80],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数6.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [424,160,15,15],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-打捞队-左4机场"
+        ]
+    },
+    "6-4e-Round5-打捞队-左4机场":{
+        "recognition": "TemplateMatch",
+        "roi" : [990,625,97,77],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数5.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [717,199,16,14],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-点击开路队"
+        ]
+    },
+    "6-4e-Round5-点击开路队":{
+        "recognition": "TemplateMatch",
+        "roi" : [990,625,97,78],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数2.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [615,351,14,14],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-选择开路队"
+        ]
+    },
+    "6-4e-Round5-选择开路队":{
+        "recognition": "OCR",
+        "roi" : [706,337,82,45],
+        "expected" : "选择",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [706,337,82,45],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-开路队-左3机场"
+        ]
+    },
+    "6-4e-Round5-开路队-左3机场":{
+        "recognition": "TemplateMatch",
+        "roi" : [990,625,97,78],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数2.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [581,192,14,16],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-点击打捞队2"
+        ]
+    },
+    "6-4e-Round5-点击打捞队2":{
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":800,
+        "target" : [546,256,14,14],
+        "post_delay":800,
+        "next":[
+            "6-4e-Round5-选择打捞队1"
+        ]
+    },
+    "6-4e-Round5-选择打捞队1":{
+        "recognition":"OCR",
+        "roi" : [634,246,83,44],
+        "expected":"选择",
+        "action":"LongPress",
+        "duration":20,
+        "pre_delay":200,
+        "target":[634,246,83,44],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-点击下一回合"
+        ]
+    },
+    "6-4e-Round5-点击下一回合":{
+        "recognition": "TemplateMatch",
+        "roi" : [990,625,97,79],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数0.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1120,533,85,31],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-打捞队-右1机场"
+        ]
+    },
+    "6-4e-Round5-打捞队-右1机场":{
+        "recognition": "OCR",
+        "roi" : [976,529,87,44],
+        "expected":"取消",
+        "action":"LongPress",
+        "duration":20,
+        "pre_delay":200,
+        "target" : [1109,148,14,15],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-打捞队-随机点右侧普通点"
+        ]
+    },
+    "6-4e-Round5-打捞队-随机点右侧普通点":{
+        "recognition": "TemplateMatch",
+        "roi" : [988,624,99,79],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数-3.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1007,511,12,13],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-点击下一回合1"
+        ]
+    },
+    "6-4e-Round5-点击下一回合1":{
+        "recognition": "TemplateMatch",
+        "roi" : [989,625,97,77],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R5计划点数-8.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1120,533,85,31],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round5-执行计划"
+        ]
+    },
+    "6-4e-Round5-执行计划":{
+        "recognition": "OCR",
+        "roi" : [976,529,87,44],
+        "expected":"取消",
+        "action":"LongPress",
+        "duration":20,
+        "pre_delay":200,
+        "target" : [1128,642,96,42],
+        "post_delay":200000,
+        "next":[
+            "6-4e-Round7-点击打捞队"
+        ]
+
+    },
+    "6-4e-Round7-点击打捞队":{
+        "recognition": "TemplateMatch",
+        "roi" : [982,620,98,99],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R7行动点数07.png",
+        "threshold":[0.9],
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [739,351,12,15],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round7-点击计划模式"
+        ]
+    },
+    "6-4e-Round7-点击计划模式":{
+        "recognition": "OCR",
+        "roi" : [1161,118,46,24],
+        "expected":"妖精",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [31,618,93,23],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round7-打捞队-敌方指挥部"
+        ]
+    },
+    "6-4e-Round7-打捞队-敌方指挥部":{
+        "recognition": "TemplateMatch",
+        "roi" : [987,625,100,80],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R7计划点数7.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [421,565,16,16],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round7-点击下一回合"
+        ]
+    },
+    "6-4e-Round7-点击下一回合":{
+        "recognition": "TemplateMatch",
+        "roi" : [983,622,104,81],
+        "template" : "combat/dollRescue/residentRescue/6-4eRescue/R7计划点数0.png",
+        "action": "LongPress",
+        "duration": 20,
+        "pre_delay":400,
+        "target" : [1117,534,91,29],
+        "post_delay":400,
+        "next":[
+            "6-4e-Round7-执行计划"
+        ]
+    },
+    "6-4e-Round7-执行计划":{
+        "recognition": "OCR",
+        "roi" : [976,529,87,44],
+        "expected":"取消",
+        "action":"LongPress",
+        "duration":20,
+        "pre_delay":200,
+        "target" : [1128,642,96,42],
+        "post_delay":35000,
+        "next":[
+            "6-4e再次作战"
+        ]
+    },
+    "6-4e再次作战":{
+        "recognition": "OCR",
+        "roi" : [277,572,188,73],
+        "expected":"再次作战",
+        "action":"LongPress",
+        "duration":20,
+        "pre_delay":200,
+        "target" : [366,609,94,27],
+        "post_delay":8000,
+        "next":[
             "6-4e开始作战"
         ],
         "interrupt": [
-            "public拆人形_人形回收",
             "6-4e-点击获得角色"
         ]
     },
@@ -1543,13 +882,11 @@
         "recognition": "DirectHit",
         "action": "LongPress",
         "duration": 20,
-        "target": [
-            386,
-            620,
-            1,
-            1
-        ],
+        "target": [386,620,1,1],
         "pre_delay": 100,
-        "timeout": 300000
+        "timeout": 600000
     }
+
+
 }
+      


### PR DESCRIPTION
取消使用自动补给，简化脚本操作
1开路队
2狗粮队
3打捞队，需要连斩boss，无锁血前排请使用高闪避前排
三队均需要携带任意妖精
将地图缩放至最小并从左下往右上拖拽至无法移动
即可开启脚本使用
<img width="722" height="367" alt="配队示例" src="https://github.com/user-attachments/assets/a5fe4e7f-84f7-4b55-9f2c-36f3f888f462" />
<img width="1280" height="721" alt="布局示例" src="https://github.com/user-attachments/assets/c198530f-5fe9-4387-845a-4c8c87b30217" />
[6-4eRescue（特征图片）.zip](https://github.com/user-attachments/files/21906967/6-4eRescue.zip)
视打捞队伍不同可能在计划行动结束时产生5-15秒不等的等待时间，有意提升效率者请自行修改相关post_delay值
