### PR TITLE
Feat: Python依赖和Github workflow

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,72 @@
+name: Python Dependencies Check
+
+on:
+  push:
+    paths:
+      - 'agent/**/*.py'
+  pull_request:
+    paths:
+      - 'agent/**/*.py'
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+        
+    - name: Install scanning dependencies
+      run: |
+        python -m pip install --upgrade pip
+        
+    - name: Ensure py_deps directory exists
+      run: |
+        mkdir -p tools/py_deps
+        
+    - name: Scan dependencies
+      run: |
+        python tools/dev/scan_dependencies.py
+        
+    - name: Check for changes
+      id: changes
+      run: |
+        if [[ -n $(git status --porcelain) ]]; then
+          echo "changes=true" >> $GITHUB_OUTPUT
+        else
+          echo "changes=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Commit and push changes
+      if: steps.changes.outputs.changes == 'true' && github.event_name == 'push'
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add tools/py_deps/requirements.txt tools/py_deps/dependency_report.json
+        git commit -m "Auto-update dependencies [skip ci]" || exit 0
+        git push
+        
+    - name: Create summary
+      run: |
+        echo "## 🔍 Python依赖检查结果" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### 📦 发现的第三方库依赖:" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        if [ -f tools/py_deps/requirements.txt ]; then
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat tools/py_deps/requirements.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### 📋 手动安装命令:" >> $GITHUB_STEP_SUMMARY
+        echo '```bash' >> $GITHUB_STEP_SUMMARY
+        echo "pip install -r tools/py_deps/requirements.txt" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### 📊 详细报告:" >> $GITHUB_STEP_SUMMARY
+        echo "依赖详细信息已保存到 \`tools/py_deps/dependency_report.json\`" >> $GITHUB_STEP_SUMMARY

--- a/tools/dev/scan_dependencies.py
+++ b/tools/dev/scan_dependencies.py
@@ -1,0 +1,119 @@
+import ast
+import os
+import sys
+import importlib.util
+from pathlib import Path
+from typing import Set, List, Dict
+
+class DependencyScanner:
+    def __init__(self, scan_dir: str):
+        self.scan_dir = Path(scan_dir)
+        self.builtin_modules = set(sys.builtin_module_names)
+        self.stdlib_modules = self._get_stdlib_modules()
+        
+    def _get_stdlib_modules(self) -> Set[str]:
+        """获取标准库模块列表"""
+        stdlib_modules = set()
+        common_stdlib = {
+            'os', 'sys', 'time', 'json', 're', 'math', 'random', 'datetime',
+            'pathlib', 'collections', 'itertools', 'functools', 'operator',
+            'traceback', 'logging', 'threading', 'subprocess', 'shutil',
+            'tempfile', 'glob', 'pickle', 'csv', 'urllib', 'http', 'socket',
+            'ssl', 'hashlib', 'base64', 'uuid', 'typing', 'abc', 'enum'
+        }
+        stdlib_modules.update(common_stdlib)
+        return stdlib_modules
+    
+    def _extract_imports_from_file(self, file_path: Path) -> Set[str]:
+        """从单个Python文件中提取import语句"""
+        imports = set()
+        
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            
+            tree = ast.parse(content)
+            
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        imports.add(alias.name.split('.')[0])
+                elif isinstance(node, ast.ImportFrom):
+                    if node.module:
+                        imports.add(node.module.split('.')[0])
+                        
+        except Exception as e:
+            print(f"警告: 无法解析文件 {file_path}: {e}")
+            
+        return imports
+    
+    def scan_directory(self) -> Dict[str, List[str]]:
+        """扫描目录中的所有Python文件"""
+        all_imports = set()
+        file_imports = {}
+        
+        for py_file in self.scan_dir.rglob("*.py"):
+            if py_file.name.startswith('.'):
+                continue
+                
+            imports = self._extract_imports_from_file(py_file)
+            file_imports[str(py_file.relative_to(self.scan_dir))] = list(imports)
+            all_imports.update(imports)
+        
+        return {
+            'all_imports': list(all_imports),
+            'file_imports': file_imports,
+            'third_party': self._filter_third_party(all_imports)
+        }
+    
+    def _filter_third_party(self, imports: Set[str]) -> List[str]:
+        """过滤出第三方库"""
+        third_party = []
+        
+        for module in imports:
+            # 跳过内置模块和标准库
+            if module in self.builtin_modules or module in self.stdlib_modules:
+                continue
+                
+            # 跳过本地模块
+            if self._is_local_module(module):
+                continue
+                
+            third_party.append(module)
+        
+        return sorted(third_party)
+    
+    def _is_local_module(self, module_name: str) -> bool:
+        """检查是否为本地模块"""
+        # 检查是否存在对应的.py文件
+        possible_paths = [
+            self.scan_dir / f"{module_name}.py",
+            self.scan_dir / module_name / "__init__.py"
+        ]
+        
+        return any(path.exists() for path in possible_paths)
+
+def main():
+    scanner = DependencyScanner("agent")
+    results = scanner.scan_directory()
+    
+    print("=== 依赖扫描结果 ===")
+    print(f"发现的第三方库: {results['third_party']}")
+    
+    output_dir = Path("tools/py_deps")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # 生成requirements.txt
+    with open(output_dir / "requirements.txt", "w") as f:
+        for lib in results['third_party']:
+            f.write(f"{lib}\n")
+    
+    print(f"已生成 tools/py_deps/requirements.txt，包含 {len(results['third_party'])} 个依赖")
+    
+    # 生成dependency_report.json
+    with open(output_dir / "dependency_report.json", "w") as f:
+        import json
+        json.dump(results, f, indent=2, ensure_ascii=False)
+
+if __name__ == "__main__":
+    main()

--- a/tools/py_deps/dependency_report.json
+++ b/tools/py_deps/dependency_report.json
@@ -1,0 +1,115 @@
+{
+  "all_imports": [
+    "typing",
+    "server",
+    "os",
+    "win32process",
+    "datetime",
+    "input",
+    "win32gui",
+    "my_reco",
+    "time",
+    "config",
+    "re",
+    "threading",
+    "PIL",
+    "ctypes",
+    "queue",
+    "traceback",
+    "include",
+    "log",
+    "json",
+    "numpy",
+    "maa",
+    "action",
+    "requests",
+    "win32api",
+    "sys",
+    "win32ui",
+    "win32con"
+  ],
+  "file_imports": {
+    "my_reco.py": [
+      "maa"
+    ],
+    "config.py": [
+      "os"
+    ],
+    "main.py": [
+      "action",
+      "server",
+      "traceback",
+      "os",
+      "my_reco",
+      "time",
+      "maa",
+      "config",
+      "sys"
+    ],
+    "action/log.py": [
+      "traceback",
+      "include",
+      "os",
+      "json",
+      "requests",
+      "config",
+      "sys"
+    ],
+    "action/init.py": [
+      "input",
+      "log"
+    ],
+    "action/input.py": [
+      "include",
+      "log"
+    ],
+    "action/include.py": [
+      "ctypes",
+      "traceback",
+      "os",
+      "win32process",
+      "json",
+      "win32gui",
+      "numpy",
+      "time",
+      "PIL",
+      "maa",
+      "re",
+      "sys",
+      "win32api",
+      "win32ui",
+      "win32con"
+    ],
+    "server/server.py": [
+      "typing",
+      "queue",
+      "traceback",
+      "json",
+      "datetime",
+      "time",
+      "action",
+      "threading"
+    ],
+    "server/init.py": [
+      "server"
+    ]
+  },
+  "third_party": [
+    "PIL",
+    "action",
+    "ctypes",
+    "include",
+    "input",
+    "log",
+    "maa",
+    "numpy",
+    "queue",
+    "requests",
+    "server",
+    "win32api",
+    "win32con",
+    "win32gui",
+    "win32process",
+    "win32ui"
+  ]
+}

--- a/tools/py_deps/requirements.txt
+++ b/tools/py_deps/requirements.txt
@@ -1,0 +1,16 @@
+PIL
+action
+ctypes
+include
+input
+log
+maa
+numpy
+queue
+requests
+server
+win32api
+win32con
+win32gui
+win32process
+win32ui


### PR DESCRIPTION
1. 新增了`tools/dev/scan_dependencies.py`，实现对`agent`中所有`.py`文件的依赖扫描； 
2. 新增了`.github/workflows/dependency-check.yml`，当发生push或PR触发——若`agent`中的`.py`文件有修改，那么： 
2.1 通过(1)中的工具对其进行依赖扫描；
2.2 将扫描的结果输出到`tools/py_deps`中，其中`dependency_report.json`为扫描报告、`requirements.txt`为依赖文档。

通过Action查看如下：

<img width="996" height="922" alt="image" src="https://github.com/user-attachments/assets/550131be-e192-4e71-8cbd-5b330c18a18c" />
