### PR TITLE
Feat: WD Timeout Update

### DIFF
--- a/agent/action/watchdog.py
+++ b/agent/action/watchdog.py
@@ -137,20 +137,45 @@ class Watchdog:
         
         return True
     
-    def feed(self, timeout_ms=30000, string_info=""):
+    def _update_timeout(self, timeout_ms, string_info=""):
+        """
+        Update timeout threshold for running watchdog
+        """
+        old_timeout = self._timeout_ms
+        self._timeout_ms = timeout_ms
+        
+        update_message = f"[WATCHDOG] Timeout Updated\n\nOld Timeout: {old_timeout}ms\n\nNew Timeout: {timeout_ms}ms\n\nInfo: {string_info}\n\nTime: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        
+        MaaLog_Info(f"Watchdog timeout updated - old: {old_timeout}ms, new: {timeout_ms}ms, info: {string_info}")
+        
+        # Send notification
+        self._send_notification(update_message)
+        
+        return True
+    
+    def feed(self, timeout_ms=None, string_info=""):
         """
         Feed the watchdog (auto-start if not running, reset timeout if running)
+        If timeout_ms is provided, always update the timeout threshold
         """
         with self._lock:
             if not self._is_running:
                 # First feed - auto start
-                MaaLog_Debug(f"Watchdog not running, auto-starting with timeout: {timeout_ms}ms, info: {string_info}")
-                return self._internal_start(timeout_ms, string_info)
+                actual_timeout = timeout_ms if timeout_ms is not None else 30000
+                MaaLog_Debug(f"Watchdog not running, auto-starting with timeout: {actual_timeout}ms, info: {string_info}")
+                return self._internal_start(actual_timeout, string_info)
             else:
-                # Subsequent feeds - reset timer
+                # Watchdog is already running
+                # Reset timer first
                 self._last_feed_time = datetime.now()
                 self._is_timeout_occurred = False  # Reset timeout flag
                 MaaLog_Debug(f"Watchdog fed at {self._last_feed_time.strftime('%Y-%m-%d %H:%M:%S')}")
+                
+                # Update timeout if provided
+                if timeout_ms is not None:
+                    MaaLog_Debug(f"Updating watchdog timeout to {timeout_ms}ms")
+                    self._update_timeout(timeout_ms, string_info)
+                
                 return True
     
     def poll(self):
@@ -223,6 +248,12 @@ class Watchdog:
         """Check if timeout has occurred"""
         with self._lock:
             return self._is_timeout_occurred
+    
+    @property
+    def current_timeout_ms(self):
+        """Get current timeout threshold"""
+        with self._lock:
+            return self._timeout_ms
 
 # Global watchdog instance
 _global_watchdog = Watchdog()
@@ -234,7 +265,7 @@ def get_global_watchdog():
 @AgentServer.custom_action("watchdog_feed")
 class WatchdogFeedAction(CustomAction):
     """
-    Feed watchdog action (auto-start if not running)
+    Feed watchdog action (auto-start if not running, update timeout if provided)
     """
     
     def run(self, context: Context, argv: CustomAction.RunArg) -> bool:
@@ -243,7 +274,7 @@ class WatchdogFeedAction(CustomAction):
             MaaLog_Debug(f"WatchdogFeedAction param: {param} (type: {type(param)})")
             
             # Parse parameters
-            timeout_ms = 30000  # Default 30 seconds
+            timeout_ms = None  # Changed to None to distinguish between "not provided" and "default value"
             string_info = ""
             
             if isinstance(param, str):
@@ -254,7 +285,9 @@ class WatchdogFeedAction(CustomAction):
                     string_info = param
             
             if isinstance(param, dict):
-                timeout_ms = param.get('timeout_ms', 30000)
+                # Only set timeout_ms if explicitly provided
+                if 'timeout_ms' in param:
+                    timeout_ms = param['timeout_ms']
                 string_info = param.get('info', '')
             
             watchdog = get_global_watchdog()

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -1401,6 +1401,14 @@
                     }
                 },
                 {
+                    "name": "看门狗测试_更新超时阈值",
+                    "pipeline_override": {
+                        "!CustomServer": {
+                            "next": "!Watchdog_Update_Test"
+                        }
+                    }
+                },
+                {
                     "name": "去除窗口装饰",
                     "pipeline_override": {
                         "!CustomServer": {

--- a/assets/resource/pipeline/tasks/Custom/Watchdog_Update.json
+++ b/assets/resource/pipeline/tasks/Custom/Watchdog_Update.json
@@ -1,0 +1,88 @@
+{
+	"!Watchdog_Update_Test": {
+		"next": [
+			"Watchdog_Update_Feed_Initial_3s"
+		]
+	},
+	"Watchdog_Update_Feed_Initial_3s": {
+		"recognition": "DirectHit",
+		"action": "Custom",
+		"custom_action": "watchdog_feed",
+		"custom_action_param": {
+			"timeout_ms": 3000,
+			"info": "初始化看门狗 - 3秒超时"
+		},
+		"pre_delay": 100,
+		"post_delay": 100,
+		"next": [
+			"Watchdog_Update_Notify_Initial_3s"
+		]
+	},
+	"Watchdog_Update_Notify_Initial_3s": {
+		"recognition": "DirectHit",
+		"action": "Custom",
+		"custom_action": "parametric_extnotify",
+		"custom_action_param": {
+			"message": "步骤1：看门狗已启动，初始超时阈值：3秒",
+			"parameters": {}
+		},
+		"pre_delay": 100,
+		"post_delay": 100,
+		"next": [
+			"Watchdog_Update_Update_To_15s"
+		]
+	},
+	"Watchdog_Update_Update_To_15s": {
+		"recognition": "DirectHit",
+		"action": "Custom",
+		"custom_action": "watchdog_feed",
+		"custom_action_param": {
+			"timeout_ms": 15000,
+			"info": "更新超时阈值到15秒"
+		},
+		"pre_delay": 100,
+		"post_delay": 100,
+		"next": [
+			"Watchdog_Update_Notify_Updated_15s"
+		]
+	},
+	"Watchdog_Update_Notify_Updated_15s": {
+		"recognition": "DirectHit",
+		"action": "Custom",
+		"custom_action": "parametric_extnotify",
+		"custom_action_param": {
+			"message": "步骤2：超时阈值已更新为15秒，开始等待10秒验证不会超时",
+			"parameters": {}
+		},
+		"pre_delay": 100,
+		"post_delay": 10000,
+		"next": [
+			"Watchdog_Update_Verify_No_Timeout"
+		]
+	},
+	"Watchdog_Update_Verify_No_Timeout": {
+		"recognition": "DirectHit",
+		"action": "Custom",
+		"custom_action": "parametric_extnotify",
+		"custom_action_param": {
+			"message": "步骤3：等待10秒完成！看门狗应该仍在正常运行（未超时），因为当前超时阈值为15秒",
+			"parameters": {}
+		},
+		"pre_delay": 100,
+		"post_delay": 1000,
+		"next": [
+			"Watchdog_Update_Final_Summary"
+		]
+	},
+	"Watchdog_Update_Final_Summary": {
+		"recognition": "DirectHit",
+		"action": "Custom",
+		"custom_action": "parametric_extnotify",
+		"custom_action_param": {
+			"message": "超时更新测试完成！验证结果：1)看门狗成功从3秒超时更新为15秒超时 2)等待10秒后看门狗仍正常运行 3)动态超时更新功能正常工作",
+			"parameters": {}
+		},
+		"pre_delay": 100,
+		"post_delay": 100
+	}
+}


### PR DESCRIPTION
1. 为看门狗增加timeout_ms更新功能； 1.1 第一次调用含有timeout_ms的wd_feed动作，看门狗将正常初始化；
1.2
后续调用含有timeout_ms的wd_feed动作，看门狗将新的timeout_ms作为超时阈值(原有逻辑为忽略该次timeout_ms)；
2. 添加一个更新超时阈值的测试用例`Watchdog_Update.json`；
3. 修改interface.json以适配(2)中的用例。

```
!Watchdog_Update_Test
⬇
Watchdog_Update_Feed_Initial_3s
(初始化看门狗 - 3秒超时)
⬇
Watchdog_Update_Notify_Initial_3s
(通知：看门狗已启动，初始超时阈值：3秒)
⬇
Watchdog_Update_Update_To_15s
(更新超时阈值到15秒)
⬇
Watchdog_Update_Notify_Updated_15s
(通知：超时阈值已更新为15秒，开始等待10秒验证)
⬇
Watchdog_Update_Verify_No_Timeout
(验证：等待10秒完成，看门狗未超时)
⬇
Watchdog_Update_Final_Summary
(测试完成总结)
```