### PR TITLE
Fix: AD零元购

### DIFF
--- a/assets/resource/pipeline/tasks/Advanced/0元购_Ad逃亡.json
+++ b/assets/resource/pipeline/tasks/Advanced/0元购_Ad逃亡.json
@@ -241,9 +241,9 @@
 		"next": [
 			"ad逃亡_结束回合1",
 			"[JumpBack]ad逃亡_结束回合_OCR"
-			// "[JumpBack]ad逃亡_开始作战"
 		]
 	},
+ // "[JumpBack]ad逃亡_开始作战"
 	"ad逃亡_开始作战1": {
 		"recognition": "OCR",
 		"roi": [1002, 604, 277, 115],


### PR DESCRIPTION
### **User description**
修复 #240 涉及的问题，主要是：

1. 对于`ad逃亡_开始作战`添加延迟(这个500ms是核心组件)，避免点击`开始作战`失败；
2. 分离回合结束的OCR与点击动作，确保在能【结束并重复任务】的条件下实现自循环；
3. 优化`结束任务`的识别条件，修改为识别回合数`01`，这里即(2)中单独分离的OCR。


___

### **PR Type**
Bug fix


___

### **Description**
- Add 500ms delay to "开始作战" action to prevent click failures

- Separate round-end OCR detection from click action for reliable loop

- Optimize task-end recognition by detecting round number "01"

- Adjust target coordinates and action parameters for better reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ad逃亡_开始作战"] -->|"pre_delay: 500ms"| B["LongPress Action"]
  B --> C["ad逃亡_结束回合_OCR"]
  C -->|"Detect round 01"| D["ad逃亡_结束回合_点击结束"]
  D -->|"LongPress"| E["Task Complete"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0元购_Ad逃亡.json</strong><dd><code>Refactor task timing and round-end detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/resource/pipeline/tasks/Advanced/0元购_Ad逃亡.json

<ul><li>Changed "ad逃亡_开始作战" target coordinates from [1002, 604, 277, 115] to <br>[1120, 660, 0, 0]<br> <li> Increased pre_delay and post_delay from 1ms to 500ms for the action<br> <li> Renamed "ad逃亡_结束回合" to "ad逃亡_结束回合_OCR" and modified recognition logic<br> <li> Changed OCR detection from "结" character to "01" round number with <br>updated ROI [416, 34, 64, 55]<br> <li> Split round-end logic into separate OCR detection and click action <br>tasks<br> <li> Added "ad逃亡_结束回合_点击结束" task for the actual click action</ul>


</details>


  </td>
  <td><a href="https://github.com/MaaGF1/MaaGF1/pull/241/files#diff-d9035694bfb972891204e0d2cc4fb961026d86cfd4ece19491517e8cb398d93f">+16/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

