### PR TITLE
Perf: 静默沙盘炼金

### DIFF
--- a/assets/resource/pipeline/tasks/Farm/Resources/Alchemy/静默沙盘炼金.json
+++ b/assets/resource/pipeline/tasks/Farm/Resources/Alchemy/静默沙盘炼金.json
@@ -534,8 +534,8 @@
 	},
 	// 第一轮战斗 第一轮战斗End
 	"静默沙盘炼金_战斗阶段_计划模式_1_等待画面加载": {
-        "recognition": "DirectHit",
-        "action": "DoNothing",
+		"recognition": "DirectHit",
+		"action": "DoNothing",
 		"post_delay": 1000,
 		"next": [
 			"静默沙盘炼金_战斗阶段_指挥官_制造补给_判断",


### PR DESCRIPTION
### **User description**
1. 移除多余的`*_鼠标抬起`节点；
2. 添加两个`_等待画面加载`用于阻塞，避免在炼金途中因为超时退出。


___

### **PR Type**
Enhancement


___

### **Description**
- Remove redundant mouse release nodes throughout pipeline

- Add wait screen load nodes with self-loop for timeout handling

- Increase post-delay for plan execution to 20000ms

- Adjust pre-delay for supply judgment to 100ms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remove mouse release nodes"] --> B["Simplify action flow"]
  C["Add wait screen load nodes"] --> D["Handle timeouts with self-loop"]
  E["Adjust timing delays"] --> F["Improve execution stability"]
  B --> G["Optimized pipeline"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>静默沙盘炼金.json</strong><dd><code>Streamline pipeline with timeout handling nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/resource/pipeline/tasks/Farm/Resources/Alchemy/静默沙盘炼金.json

<ul><li>Removed 8 redundant mouse release nodes (DoNothing actions) that <br>followed LongPress actions<br> <li> Added 2 new wait screen load nodes with self-referencing loops for <br>timeout handling<br> <li> Increased post-delay for plan execution from 10000ms to 20000ms<br> <li> Reduced pre-delay for supply judgment from 500ms to 100ms<br> <li> Simplified action flow by eliminating unnecessary intermediate nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/MaaGF1/MaaGF1/pull/262/files#diff-daff2db07f792d722b8073f73e19e8e91ee41af0078e4fb7cc09dfc594005496">+24/-85</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

