### PR TITLE
Fix: 为Luna新增屏蔽SendInput(特指滚轮)

### DIFF
--- a/tools/hack/luna/hook.js
+++ b/tools/hack/luna/hook.js
@@ -1,83 +1,127 @@
 // tools/hack/luna/hook.js
 
 var State = {
-    mode: "inject", // Default to inject mode for Luna
-    fakePos: { x: 0, y: 0 },
-    hwnd: null
+	mode: "inject", 
+	fakePos: { x: 0, y: 0 },
+	blockWheel: true, // Default: Block physical wheel
+	gameHwnd: null
 };
 
+// --- Constants ---
+var RIM_TYPEMOUSE = 0;
+var RI_MOUSE_WHEEL = 0x0400;
+
 function debug_hook() {
-    // 1. Find User32.dll
-    var user32 = Process.findModuleByName("user32.dll");
-    if (!user32) {
-        user32 = Process.findModuleByName("User32.dll");
-    }
+	var user32 = Process.findModuleByName("user32.dll");
+	if (!user32) user32 = Process.findModuleByName("User32.dll");
+	if (!user32) {
+		send({ type: 'error', stack: "user32.dll not found" });
+		return;
+	}
 
-    if (!user32) {
-        send({ type: 'error', stack: "user32.dll not found" });
-        return;
-    }
+	var ptr_ScreenToClient = user32.findExportByName("ScreenToClient");
+	var ptr_GetCursorPos = user32.findExportByName("GetCursorPos");
+	var ptr_GetRawInputData = user32.findExportByName("GetRawInputData");
 
-    // 2. Resolve Exports
-    function resolve_export(mod, name) {
-        return mod.findExportByName(name);
-    }
+	// Helper: Get Pointer Size for struct offsets
+	var ptrSize = Process.pointerSize; // 4 or 8
 
-    var ptr_ScreenToClient = resolve_export(user32, "ScreenToClient");
-    var ptr_GetCursorPos = resolve_export(user32, "GetCursorPos");
+	// 1. Hook ScreenToClient (Coordinate Spoofing)
+	if (ptr_ScreenToClient) {
+		Interceptor.attach(ptr_ScreenToClient, {
+			onEnter: function(args) {
+				this.hwnd = args[0];
+				this.lpPoint = args[1];
+				if (State.gameHwnd === null) State.gameHwnd = this.hwnd;
+			},
+			onLeave: function(retval) {
+			if (retval.toInt32() === 0) return;
+				try {
+					if (State.mode === "inject") {
+						this.lpPoint.writeS32(parseInt(State.fakePos.x));
+						this.lpPoint.add(4).writeS32(parseInt(State.fakePos.y));
+					}
+				} catch (e) {}
+			}
+		});
+	}
 
-    // 3. Hook ScreenToClient
-    if (ptr_ScreenToClient) {
-        Interceptor.attach(ptr_ScreenToClient, {
-            onEnter: function(args) {
-                this.hwnd = args[0];
-                this.lpPoint = args[1];
-            },
-            onLeave: function(retval) {
-                if (retval.toInt32() === 0) return;
-                try {
-                    if (State.mode === "inject") {
-                        this.lpPoint.writeS32(parseInt(State.fakePos.x));
-                        this.lpPoint.add(4).writeS32(parseInt(State.fakePos.y));
-                    }
-                } catch (e) {}
-            }
-        });
-    }
+	// 2. Hook GetCursorPos (Backup Coordinate Spoofing)
+	if (ptr_GetCursorPos) {
+		Interceptor.attach(ptr_GetCursorPos, {
+			onEnter: function(args) { this.lpPoint = args[0]; },
+			onLeave: function(retval) {
+				if (retval.toInt32() === 0) return;
+				try {
+					if (State.mode === "inject") {
+						this.lpPoint.writeS32(parseInt(State.fakePos.x));
+						this.lpPoint.add(4).writeS32(parseInt(State.fakePos.y));
+					}
+				} catch (e) {}
+			}
+		});
+	}
 
-    // 4. Hook GetCursorPos (Backup for some Unity versions)
-    if (ptr_GetCursorPos) {
-        Interceptor.attach(ptr_GetCursorPos, {
-            onEnter: function(args) {
-                this.lpPoint = args[0];
-            },
-            onLeave: function(retval) {
-                if (retval.toInt32() === 0) return;
-                try {
-                    if (State.mode === "inject") {
-                        this.lpPoint.writeS32(parseInt(State.fakePos.x));
-                        this.lpPoint.add(4).writeS32(parseInt(State.fakePos.y));
-                    }
-                } catch (e) {}
-            }
-        });
-    }
-    
-    send({ type: 'info', payload: "Hooks installed successfully." });
+	// 3. Hook GetRawInputData (Blocks Physical/SendInput Wheel)
+	if (ptr_GetRawInputData) {
+		Interceptor.attach(ptr_GetRawInputData, {
+			onEnter: function(args) {
+				this.pData = args[2];
+				this.uiCommand = args[1].toInt32(); // RID_INPUT = 0x10000003
+			},
+			onLeave: function(retval) {
+				// If successful and we are reading Input Data (not header)
+				if (retval.toInt32() > 0 && this.pData.isNull() === false && State.blockWheel) {
+					try {
+						// RAWINPUTHEADER is at pData
+						// DWORD dwType is at offset 0
+						var dwType = this.pData.readU32();
+						
+						if (dwType === RIM_TYPEMOUSE) {
+							// RAWMOUSE struct starts after header
+							// Header size: x64=24 bytes, x86=16 bytes
+							var headerSize = (ptrSize === 8) ? 24 : 16;
+							var rawMousePtr = this.pData.add(headerSize);
+							
+							// RAWMOUSE Layout:
+							// Offset 0: usFlags (2 bytes)
+							// Offset 4: usButtonFlags (2 bytes) - This contains RI_MOUSE_WHEEL
+							// Offset 6: usButtonData (2 bytes) - This contains Wheel Delta
+							
+							var usButtonFlags = rawMousePtr.add(4).readU16();
+							
+							// If this is SendInput from user's real mouse, let game do nothing
+							if ((usButtonFlags & RI_MOUSE_WHEEL) === RI_MOUSE_WHEEL) {
+								rawMousePtr.add(4).writeU16(usButtonFlags & ~RI_MOUSE_WHEEL);
+								rawMousePtr.add(6).writeU16(0);
+							}
+						}
+					} catch (e) {
+						// send({type: 'error', stack: "RawInput Error: " + e.message});
+					}
+				}
+			}
+		});
+	}
+
+	send({ type: 'info', payload: "Hooks installed: Pos(ScreenToClient/GetCursorPos), Wheel(RawInput Only)" });
 }
 
 // ================= Message Processing =================
 recv(function onMessage(message) {
-    if (message.type === "UPDATE_POS") {
-        State.fakePos.x = message.x;
-        State.fakePos.y = message.y;
-        // No log here to keep performance high
-    }
-    recv(onMessage);
+	if (message.type === "UPDATE_POS") {
+		State.fakePos.x = message.x;
+		State.fakePos.y = message.y;
+	}
+	else if (message.type === "SET_WHEEL") {
+		State.blockWheel = !message.enable;
+		send({ type: 'info', payload: "Wheel Block: " + State.blockWheel });
+	}
+	recv(onMessage);
 });
 
 try {
-    debug_hook();
+	debug_hook();
 } catch (e) {
-    send({ type: 'error', stack: e.message });
+	send({ type: 'error', stack: e.message });
 }


### PR DESCRIPTION
### **User description**
1. 在`tools/hack/luna/hook.js`新增对滚轮的屏蔽，避免用户在其他窗口的滚轮动作影响到游戏。


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add wheel input blocking via GetRawInputData hook

- Prevent physical/SendInput wheel events from affecting game

- Support dynamic wheel blocking toggle via SET_WHEEL message

- Improve code structure with constants and better error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Wheel Input"] --> B["GetRawInputData Hook"]
  B --> C{"blockWheel Enabled?"}
  C -->|Yes| D["Strip RI_MOUSE_WHEEL Flag"]
  C -->|No| E["Pass Through"]
  D --> F["Game Receives No Wheel"]
  E --> G["Game Receives Wheel"]
  H["SET_WHEEL Message"] --> C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hook.js</strong><dd><code>Implement wheel input blocking via GetRawInputData hook</code>&nbsp; &nbsp; </dd></summary>
<hr>

tools/hack/luna/hook.js

<ul><li>Add <code>blockWheel</code> state variable and wheel-related constants <br>(RIM_TYPEMOUSE, RI_MOUSE_WHEEL)<br> <li> Implement GetRawInputData hook to intercept and strip wheel input <br>flags from raw mouse data<br> <li> Add SET_WHEEL message handler to dynamically toggle wheel blocking<br> <li> Refactor code formatting (spaces to tabs) and improve error handling<br> <li> Update success message to reflect newly installed wheel blocking hook</ul>


</details>


  </td>
  <td><a href="https://github.com/MaaGF1/MaaGF1/pull/268/files#diff-a1b7809ba693b025e5a3e2305b2caf78f6862e0ffe8c6a73f135791ae03ee62a">+107/-63</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

