### PR TITLE
修复public/中脚本点击导航栏时的误判问题。

### DIFF
--- a/assets/resource/pipeline/tasks/public/factory/二星人形拆解.json
+++ b/assets/resource/pipeline/tasks/public/factory/二星人形拆解.json
@@ -55,6 +55,7 @@
 		"template": "storage/navi.png",
 		"action": "LongPress",
 		"duration": 20,
+		"target": [216, 73, 0, 0],
 		"pre_delay": 800,
 		"post_wait_freezes": 200,
 		"next": [

--- a/assets/resource/pipeline/tasks/public/factory/二星装备拆解.json
+++ b/assets/resource/pipeline/tasks/public/factory/二星装备拆解.json
@@ -56,6 +56,7 @@
 		"template": "storage/navi.png",
 		"action": "LongPress",
 		"duration": 20,
+		"target": [216, 73, 0, 0],
 		"pre_delay": 800,
 		"post_wait_freezes": 200,
 		"next": [

--- a/assets/resource/pipeline/tasks/public/factory/人形全拆解.json
+++ b/assets/resource/pipeline/tasks/public/factory/人形全拆解.json
@@ -253,6 +253,7 @@
 		"template": "storage/navi.png",
 		"action": "LongPress",
 		"duration": 20,
+		"target": [216, 73, 0, 0],
 		"pre_delay": 800,
 		"post_wait_freezes": 200,
 		"next": [

--- a/assets/resource/pipeline/tasks/public/factory/装备全拆解.json
+++ b/assets/resource/pipeline/tasks/public/factory/装备全拆解.json
@@ -228,6 +228,7 @@
 		"template": "storage/navi.png",
 		"action": "LongPress",
 		"duration": 20,
+		"target": [216, 73, 0, 0],
 		"pre_delay": 800,
 		"post_wait_freezes": 200,
 		"next": [

--- a/assets/resource/pipeline/tasks/public/factory/装备强化.json
+++ b/assets/resource/pipeline/tasks/public/factory/装备强化.json
@@ -136,6 +136,7 @@
 		"template": "storage/navi.png",
 		"action": "LongPress",
 		"duration": 20,
+		"target": [216, 73, 0, 0],
 		"pre_delay": 500,
 		"post_wait_freezes": 200,
 		"next": [


### PR DESCRIPTION
如视频所示，识别并点击导航栏按钮"storage/navi.png"时，有小概率点到左侧边缘而误判为回到主界面。0元购为事故多发地点。
因此固定了点击的target。

https://github.com/user-attachments/assets/37828a15-47ff-464e-9ef5-e12ba4238a45



